### PR TITLE
Fixed the issue where quorum query failed due to clock being too close

### DIFF
--- a/ai-agent/__tests__/contract.test.ts
+++ b/ai-agent/__tests__/contract.test.ts
@@ -15,7 +15,7 @@ describe("X Tweet Preview Test", () => {
         // standard: "ERC20",
         // governorTokenAddress: "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       });
-      console.log(DegovHelpers.safeJsonStringify(result));
+      console.log(result);
       expect(result).toEqual({
         quorum: 1000000000000000000000000n,
       });
@@ -35,7 +35,7 @@ describe("X Tweet Preview Test", () => {
         governorTokenAddress: "0xdafa555e2785DC8834F4Ea9D1ED88B6049142999",
         includeDecimals: true,
       });
-      console.log(DegovHelpers.safeJsonStringify(result));
+      console.log(result);
       expect(result).toEqual({
         quorum: 40000000000000000000000000n,
         decimals: 18n,
@@ -57,11 +57,11 @@ describe("X Tweet Preview Test", () => {
         governorTokenAddress: "0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187",
         includeDecimals: true,
       });
-      console.log(DegovHelpers.safeJsonStringify(result));
-      // expect(result).toEqual({
-      //   quorum: 40000000000000000000000000n,
-      //   decimals: 18n,
-      // });
+      console.log(result);
+      expect(result).toEqual({
+        quorum: 3000000000000000000000000n,
+        decimals: 18n,
+      });
     },
     1000 * 60
   );

--- a/ai-agent/__tests__/contract.test.ts
+++ b/ai-agent/__tests__/contract.test.ts
@@ -1,7 +1,6 @@
 import { DegovContract } from "../src/internal/contracts";
-import { DegovHelpers } from "../src/helpers";
 
-describe("X Tweet Preview Test", () => {
+describe("Contract test", () => {
   const contract = new DegovContract();
 
   it(

--- a/ai-agent/__tests__/contract.test.ts
+++ b/ai-agent/__tests__/contract.test.ts
@@ -1,4 +1,5 @@
 import { DegovContract } from "../src/internal/contracts";
+import { DegovHelpers } from "../src/helpers";
 
 describe("X Tweet Preview Test", () => {
   const contract = new DegovContract();
@@ -14,7 +15,7 @@ describe("X Tweet Preview Test", () => {
         // standard: "ERC20",
         // governorTokenAddress: "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       });
-      console.log(result);
+      console.log(DegovHelpers.safeJsonStringify(result));
       expect(result).toEqual({
         quorum: 1000000000000000000000000n,
       });
@@ -34,11 +35,33 @@ describe("X Tweet Preview Test", () => {
         governorTokenAddress: "0xdafa555e2785DC8834F4Ea9D1ED88B6049142999",
         includeDecimals: true,
       });
-      console.log(result);
+      console.log(DegovHelpers.safeJsonStringify(result));
       expect(result).toEqual({
         quorum: 40000000000000000000000000n,
         decimals: 18n,
       });
+    },
+    1000 * 60
+  );
+
+
+  it(
+    "Check quorum erc20 - unlockdao - timestamp",
+    async () => {
+      const result = await contract.quorum({
+        chainId: 8453,
+        endpoint: "https://base-rpc.publicnode.com",
+        contractAddress: "0x65bA0624403Fc5Ca2b20479e9F626eD4D78E0aD9",
+
+        standard: "ERC20",
+        governorTokenAddress: "0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187",
+        includeDecimals: true,
+      });
+      console.log(DegovHelpers.safeJsonStringify(result));
+      // expect(result).toEqual({
+      //   quorum: 40000000000000000000000000n,
+      //   decimals: 18n,
+      // });
     },
     1000 * 60
   );

--- a/ai-agent/src/internal/contracts/degov.ts
+++ b/ai-agent/src/internal/contracts/degov.ts
@@ -19,6 +19,131 @@ import { DegovHelpers } from "../../helpers";
 import { privateKeyToAccount } from "viem/accounts";
 import { EnvReader } from "../../integration/env-reader";
 
+const ABI_ERROR_GOVERNOR = [
+  { inputs: [], name: "CheckpointUnorderedInsertion", type: "error" },
+  { inputs: [], name: "FailedCall", type: "error" },
+  {
+    inputs: [{ internalType: "address", name: "voter", type: "address" }],
+    name: "GovernorAlreadyCastVote",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+    name: "GovernorAlreadyQueuedProposal",
+    type: "error",
+  },
+  { inputs: [], name: "GovernorDisabledDeposit", type: "error" },
+  {
+    inputs: [
+      { internalType: "address", name: "proposer", type: "address" },
+      { internalType: "uint256", name: "votes", type: "uint256" },
+      { internalType: "uint256", name: "threshold", type: "uint256" },
+    ],
+    name: "GovernorInsufficientProposerVotes",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "targets", type: "uint256" },
+      { internalType: "uint256", name: "calldatas", type: "uint256" },
+      { internalType: "uint256", name: "values", type: "uint256" },
+    ],
+    name: "GovernorInvalidProposalLength",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "quorumNumerator",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "quorumDenominator",
+        type: "uint256",
+      },
+    ],
+    name: "GovernorInvalidQuorumFraction",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "address", name: "voter", type: "address" }],
+    name: "GovernorInvalidSignature",
+    type: "error",
+  },
+  { inputs: [], name: "GovernorInvalidVoteParams", type: "error" },
+  { inputs: [], name: "GovernorInvalidVoteType", type: "error" },
+  {
+    inputs: [
+      { internalType: "uint256", name: "votingPeriod", type: "uint256" },
+    ],
+    name: "GovernorInvalidVotingPeriod",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+    name: "GovernorNonexistentProposal",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
+    name: "GovernorNotQueuedProposal",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "GovernorOnlyExecutor",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "GovernorOnlyProposer",
+    type: "error",
+  },
+  { inputs: [], name: "GovernorQueueNotImplemented", type: "error" },
+  {
+    inputs: [{ internalType: "address", name: "proposer", type: "address" }],
+    name: "GovernorRestrictedProposer",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "proposalId", type: "uint256" },
+      {
+        internalType: "enum IGovernor.ProposalState",
+        name: "current",
+        type: "uint8",
+      },
+      { internalType: "bytes32", name: "expectedStates", type: "bytes32" },
+    ],
+    name: "GovernorUnexpectedProposalState",
+    type: "error",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "account", type: "address" },
+      { internalType: "uint256", name: "currentNonce", type: "uint256" },
+    ],
+    name: "InvalidAccountNonce",
+    type: "error",
+  },
+  { inputs: [], name: "InvalidShortString", type: "error" },
+  {
+    inputs: [
+      { internalType: "uint8", name: "bits", type: "uint8" },
+      { internalType: "uint256", name: "value", type: "uint256" },
+    ],
+    name: "SafeCastOverflowedUintDowncast",
+    type: "error",
+  },
+  {
+    inputs: [{ internalType: "string", name: "str", type: "string" }],
+    name: "StringTooLong",
+    type: "error",
+  },
+];
+
 const ABI_FUNCTION_STATE = [
   {
     inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
@@ -61,12 +186,13 @@ const ABI_FUNCTION_CAST_VOTE_WITH_REASON = [
 
 const ABI_FUNCTION_QUORUM = [
   {
-    inputs: [{ internalType: "uint256", name: "blockNumber", type: "uint256" }],
+    inputs: [{ internalType: "uint256", name: "timepoint", type: "uint256" }],
     name: "quorum",
     outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
     stateMutability: "view",
     type: "function",
   },
+  ...ABI_ERROR_GOVERNOR,
 ];
 
 const ABI_FUNCTION_CLOCK = [
@@ -239,8 +365,10 @@ export class DegovContract {
   async quorum(options: QueryQuorumOptions): Promise<QuorumResult | undefined> {
     const client = this.client(options);
 
+    let clockMode: ClockMode | undefined = ClockMode.BlockNumber;
     let clock: bigint | undefined = undefined;
     try {
+      clockMode = await this.clockMode(options);
       const result = await client.readContract({
         address: options.contractAddress,
         abi: ABI_FUNCTION_CLOCK,
@@ -252,25 +380,34 @@ export class DegovContract {
     } catch (e: any) {
       console.warn(`failed to query clock: ${e}`);
     }
+
     if (!clock) {
-      const clockMode = await this.clockMode(options);
       const latestBlock = await client.getBlock();
       switch (clockMode) {
         case ClockMode.Timestamp:
-          clock = latestBlock.timestamp - 60n * 3n;
+          clock = latestBlock.timestamp;
           break;
         case ClockMode.BlockNumber:
-          // Use a block number that's safely in the past to avoid "block not yet mined" error
-          clock = latestBlock.number - 10n;
+          clock = latestBlock.number;
           break;
       }
+    }
+
+    switch (clockMode) {
+      case ClockMode.Timestamp:
+        clock = clock - 60n * 3n;
+        break;
+      case ClockMode.BlockNumber:
+        // Use a block number that's safely in the past to avoid "block not yet mined" error
+        clock = clock - 10n;
+        break;
     }
 
     const quorumResult = await client.readContract({
       address: options.contractAddress,
       abi: ABI_FUNCTION_QUORUM,
       functionName: "quorum",
-      args: [clock],
+      args: [clock.toString()],
     });
     if (!quorumResult) {
       return undefined;

--- a/ai-agent/src/internal/contracts/degov.ts
+++ b/ai-agent/src/internal/contracts/degov.ts
@@ -19,131 +19,6 @@ import { DegovHelpers } from "../../helpers";
 import { privateKeyToAccount } from "viem/accounts";
 import { EnvReader } from "../../integration/env-reader";
 
-const ABI_ERROR_GOVERNOR = [
-  { inputs: [], name: "CheckpointUnorderedInsertion", type: "error" },
-  { inputs: [], name: "FailedCall", type: "error" },
-  {
-    inputs: [{ internalType: "address", name: "voter", type: "address" }],
-    name: "GovernorAlreadyCastVote",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
-    name: "GovernorAlreadyQueuedProposal",
-    type: "error",
-  },
-  { inputs: [], name: "GovernorDisabledDeposit", type: "error" },
-  {
-    inputs: [
-      { internalType: "address", name: "proposer", type: "address" },
-      { internalType: "uint256", name: "votes", type: "uint256" },
-      { internalType: "uint256", name: "threshold", type: "uint256" },
-    ],
-    name: "GovernorInsufficientProposerVotes",
-    type: "error",
-  },
-  {
-    inputs: [
-      { internalType: "uint256", name: "targets", type: "uint256" },
-      { internalType: "uint256", name: "calldatas", type: "uint256" },
-      { internalType: "uint256", name: "values", type: "uint256" },
-    ],
-    name: "GovernorInvalidProposalLength",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256",
-        name: "quorumNumerator",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "quorumDenominator",
-        type: "uint256",
-      },
-    ],
-    name: "GovernorInvalidQuorumFraction",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "address", name: "voter", type: "address" }],
-    name: "GovernorInvalidSignature",
-    type: "error",
-  },
-  { inputs: [], name: "GovernorInvalidVoteParams", type: "error" },
-  { inputs: [], name: "GovernorInvalidVoteType", type: "error" },
-  {
-    inputs: [
-      { internalType: "uint256", name: "votingPeriod", type: "uint256" },
-    ],
-    name: "GovernorInvalidVotingPeriod",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
-    name: "GovernorNonexistentProposal",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
-    name: "GovernorNotQueuedProposal",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "address", name: "account", type: "address" }],
-    name: "GovernorOnlyExecutor",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "address", name: "account", type: "address" }],
-    name: "GovernorOnlyProposer",
-    type: "error",
-  },
-  { inputs: [], name: "GovernorQueueNotImplemented", type: "error" },
-  {
-    inputs: [{ internalType: "address", name: "proposer", type: "address" }],
-    name: "GovernorRestrictedProposer",
-    type: "error",
-  },
-  {
-    inputs: [
-      { internalType: "uint256", name: "proposalId", type: "uint256" },
-      {
-        internalType: "enum IGovernor.ProposalState",
-        name: "current",
-        type: "uint8",
-      },
-      { internalType: "bytes32", name: "expectedStates", type: "bytes32" },
-    ],
-    name: "GovernorUnexpectedProposalState",
-    type: "error",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "currentNonce", type: "uint256" },
-    ],
-    name: "InvalidAccountNonce",
-    type: "error",
-  },
-  { inputs: [], name: "InvalidShortString", type: "error" },
-  {
-    inputs: [
-      { internalType: "uint8", name: "bits", type: "uint8" },
-      { internalType: "uint256", name: "value", type: "uint256" },
-    ],
-    name: "SafeCastOverflowedUintDowncast",
-    type: "error",
-  },
-  {
-    inputs: [{ internalType: "string", name: "str", type: "string" }],
-    name: "StringTooLong",
-    type: "error",
-  },
-];
-
 const ABI_FUNCTION_STATE = [
   {
     inputs: [{ internalType: "uint256", name: "proposalId", type: "uint256" }],
@@ -192,7 +67,6 @@ const ABI_FUNCTION_QUORUM = [
     stateMutability: "view",
     type: "function",
   },
-  ...ABI_ERROR_GOVERNOR,
 ];
 
 const ABI_FUNCTION_CLOCK = [


### PR DESCRIPTION


```

[2025-08-21 06:12:43.724 +0000] ERROR: [task-vote] Error fetching quorum for DAO Unlock Protocol: The contract function "quorum" reverted with the following signature:
0xecd3f81e
Unable to decode signature "0xecd3f81e" as it was not found on the provided ABI.
Make sure you are using the correct ABI and that the error exists on it.
You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xecd3f81e.
Contract Call:
address:   0x65bA0624403Fc5Ca2b20479e9F626eD4D78E0aD9
function:  quorum(uint256 blockNumber)
args:            (1755756761)
Docs: https://viem.sh/docs/contract/decodeErrorResult
Version: viem@2.34.0

```


